### PR TITLE
Removed PlayReady laurl to test if Widevine works in Edge.

### DIFF
--- a/vuplay.js
+++ b/vuplay.js
@@ -21,8 +21,7 @@
             drm: {
                 servers: {
                     "com.widevine.alpha":
-                        "https://widevine-proxy.drm.technology/proxy",
-                    "com.microsoft.playready": playReadyLaURL
+                        "https://widevine-proxy.drm.technology/proxy"
                 }
             }
         });


### PR DESCRIPTION
Removed PlayReady laurl to test if Widevine works in new Chromium based Edge.